### PR TITLE
debian/rules: Enable libdav1d for fast AV1 decoding

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,6 +53,8 @@ Build-Depends:
  libchromaprint-dev <!pkg.ffmpeg.stage1>,
 # --enable-libcodec2
  libcodec2-dev,
+# --enable-libdav1d
+ libdav1d-dev,
 # --enable-libdc1394
  libdc1394-22-dev [linux-any],
 # --enable-libdrm

--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,6 @@ FLAVORS = standard extra static
 # The following flags are not added, because the necessary libraries are not in Debian:
 #   --enable-decklink
 #   --enable-libcelt                (see #676592: removed from Debian as abandoned upstream, replaced by opus)
-#   --enable-libdav1d
 #   --enable-libdavs2               (only in experimental)
 #   --enable-libilbc                (see #675959 for the RFP bug)
 #   --enable-libklvanc
@@ -68,6 +67,7 @@ CONFIG := --prefix=/usr \
 	--enable-libcaca \
 	--enable-libcdio \
 	--enable-libcodec2 \
+	--enable-libdav1d \
 	--enable-libflite \
 	--enable-libfontconfig \
 	--enable-libfreetype \


### PR DESCRIPTION
In preparation for for AV1 support